### PR TITLE
Add support to pdf files selected via MediaLib dialog

### DIFF
--- a/admin/src/components/CKEditor/index.js
+++ b/admin/src/components/CKEditor/index.js
@@ -56,7 +56,7 @@ const Editor = ({ onChange, name, value, disabled }) => {
           newValue = `${newValue}${imgTag}`;
         }
       } else if (asset.mime.includes("application/pdf")) {
-        const downloadTag = `<a href="${asset.url}" download="${asset.alt}">${asset.alt || 'Download PDF'}</a>`
+        const downloadTag = `<a href="${prefixFileUrlWithBackendUrl(asset.url)}" download="${asset.alt}">${asset.alt || 'Download PDF'}</a>`
         newValue = `${newValue}${downloadTag}`
       }
       // Handle videos and other type of files by adding some code

--- a/admin/src/components/CKEditor/index.js
+++ b/admin/src/components/CKEditor/index.js
@@ -55,6 +55,9 @@ const Editor = ({ onChange, name, value, disabled }) => {
           const imgTag = `<img src="${asset.url}" alt="${asset.alt}"></img>`;
           newValue = `${newValue}${imgTag}`;
         }
+      } else if (asset.mime.includes("application/pdf")) {
+        const downloadTag = `<a href="${asset.url}" download="${asset.alt}">${asset.alt || 'Download PDF'}</a>`
+        newValue = `${newValue}${downloadTag}`
       }
       // Handle videos and other type of files by adding some code
     });


### PR DESCRIPTION
This addition enable users to select PDF files from the MediaLib dialog. These PDF files will be rendered as link. Also, the `download` attribute is added to the link if `config.editor.htmlSupport.allow` is updated:

```js
module.exports = () => ({
  ckeditor: {
    enabled: true,
    config: {
      editor: {
        htmlSupport: {
          allow: [
            {
              name: 'img',
              attributes: {
                sizes: true,
                loading: true,
              }
            },
            {
              name: 'a',
              attributes: {
                href: true,
                download: true
              }
            }
          ]
        }
      }
    }
  }
})
```