### PR TITLE
Support non-JSON config properties (such as callbacks and regexes) through config/ckeditor.js

### DIFF
--- a/admin/src/components/CKEditor/index.js
+++ b/admin/src/components/CKEditor/index.js
@@ -70,6 +70,11 @@ const Editor = ({ onChange, name, value, disabled }) => {
       request(`/${pluginId}/config/${key}`, { method: "GET" });
 
   const requestEditorConfigJs = async () => {
+    const url = strapi.backendURL !== '/'
+        ? `/${strapi.backendURL}${pluginId}/editor-config-script`
+        : `/${pluginId}/editor-config-script`
+
+    // Can't use `request` helper, because it is hardcoded to try to convert response to JSON
     const response = await fetch(`/${pluginId}/editor-config-script`, {
       method: 'GET',
       headers: { Authorization: `Bearer ${auth.getToken()}` },

--- a/admin/src/components/CKEditor/index.js
+++ b/admin/src/components/CKEditor/index.js
@@ -71,7 +71,7 @@ const Editor = ({ onChange, name, value, disabled }) => {
 
   const requestEditorConfigJs = async () => {
     const url = strapi.backendURL !== '/'
-        ? `/${strapi.backendURL}${pluginId}/editor-config-script`
+        ? `${strapi.backendURL}/${pluginId}/editor-config-script`
         : `/${pluginId}/editor-config-script`
 
     // Can't use `request` helper, because it is hardcoded to try to convert response to JSON

--- a/admin/src/components/CKEditor/index.js
+++ b/admin/src/components/CKEditor/index.js
@@ -75,7 +75,7 @@ const Editor = ({ onChange, name, value, disabled }) => {
         : `/${pluginId}/editor-config-script`
 
     // Can't use `request` helper, because it is hardcoded to try to convert response to JSON
-    const response = await fetch(`/${pluginId}/editor-config-script`, {
+    const response = await fetch(url, {
       method: 'GET',
       headers: { Authorization: `Bearer ${auth.getToken()}` },
     });

--- a/server/controllers/config.js
+++ b/server/controllers/config.js
@@ -10,6 +10,12 @@ module.exports = {
       const config = await strapi.plugin('ckeditor').service('config').getConfig(configKey);
       ctx.send(config);
     }
-    
+
   },
+
+  getEditorConfigScript: async (ctx) => {
+    const config = await strapi.plugin('ckeditor').service('config').getEditorConfigScript();
+    ctx.headers['Content-Type'] = 'application/javascript';
+    ctx.send(config);
+  }
 };

--- a/server/controllers/config.js
+++ b/server/controllers/config.js
@@ -15,7 +15,7 @@ module.exports = {
 
   getEditorConfigScript: async (ctx) => {
     const config = await strapi.plugin('ckeditor').service('config').getEditorConfigScript();
-    ctx.headers['Content-Type'] = 'application/javascript';
+    ctx.type = 'application/javascript';
     ctx.send(config);
   }
 };

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,8 +1,16 @@
 module.exports = [
-  {
-    method: 'GET',
-    path: '/config/:configKey',
-    handler: 'config.getConfig',
-    config: { policies: [] },
-  }
+    {
+        method: 'GET',
+        path: '/config/:configKey',
+        handler: 'config.getConfig',
+        config: {policies: []},
+    },
+    {
+        method: 'GET',
+        path: '/editor-config-script',
+        handler: 'config.getEditorConfigScript',
+        config: {
+            policies: [() => true] // public
+        },
+    }
 ];

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -7,10 +7,10 @@ module.exports = [
     },
     {
         method: 'GET',
-        path: '/editor-config-script',
+        path: '/editor-config-script.js',
         handler: 'config.getEditorConfigScript',
         config: {
-            policies: [() => true] // public
+            auth: false // Assume CKEditor config is not sensitive. We can't send a JWT token in a static script tag.
         },
     }
 ];

--- a/server/services/config.js
+++ b/server/services/config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const fs = require("fs");
+
 /**
  * config.js configuration service
  */
@@ -8,6 +10,16 @@ module.exports = ({ strapi }) => {
   return {
     getConfig(key = 'editor') {
       return strapi.plugin('ckeditor').config(key) ?? {};
+    },
+    getEditorConfigScript() {
+      const appDir = process.cwd();
+      const isTSProject = fs.existsSync(`${appDir}/dist`);
+      const jsDir = isTSProject ? `${appDir}/dist` : appDir;
+
+      const filename = `${jsDir}/config/ckeditor.js`;
+      return fs.existsSync(filename)
+        ? fs.readFileSync(filename)
+        : undefined // empty script tag causes no problems
     },
     getUploadConfig(name) {
       return strapi.plugin('upload').service(name) ?? {};

--- a/server/services/config.js
+++ b/server/services/config.js
@@ -19,7 +19,7 @@ module.exports = ({ strapi }) => {
       const filename = `${jsDir}/config/ckeditor.js`;
       return fs.existsSync(filename)
         ? fs.readFileSync(filename)
-        : undefined // empty script tag causes no problems
+        : 'globalThis.ckEditorConfig = null' // empty script tag causes no problems
     },
     getUploadConfig(name) {
       return strapi.plugin('upload').service(name) ?? {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@ckeditor/ckeditor5-react@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-react/-/ckeditor5-react-5.0.0.tgz#b9ad16bb84415beff0b555ddc92d5e184d41f5a1"
-  integrity sha512-5E/Npua1goikPdbx6GpeFNwOem+lslgYs2r3CycXcbxa3/d9C6ZBVpWppLk3rlRcUKTOXvGNkjfqRoGk9QhATA==
+"@ckeditor/ckeditor5-react@5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-react/-/ckeditor5-react-5.0.2.tgz#446518e1d7ce842c63fc6ac24e818cc78a753903"
+  integrity sha512-pN4acvCAIsuXaZDMttqy4dNBKXiJ6AS6P8NM3ggMc/rQkMIPp3YPhDWWf+pyQLUiewj1Bfr5EFeBfcXPQTOn+Q==
   dependencies:
     prop-types "^15.7.2"
 


### PR DESCRIPTION
This PR allows creating a `config/ckeditor.js` (or .ts) in a Strapi project to as a replacement for the `editor:` section in `config/plugins.ts`.

In config/plugins.ts, properties which are non serializable, such as regexes and callbacks, would get truncated when fetching the config. This makes it impossible to configure, for example, [`mediaEmbed` providers](https://ckeditor.com/docs/ckeditor5/latest/api/module_media-embed_mediaembed-MediaEmbedProvider.html).

This PR tackles the problem by having a config/ckeditor.js inserted in a <script> tag, and assigning that to the CKEditor config.

Example use case to make `mediaEmbed` use `youtube-nocookie.com` when a YT video is inserted:
```js
// config/ckeditor.js
globalThis.ckEditorConfig = {
    toolbar: {
        items: [
          ...
        ]
    },
    mediaEmbed: {
        previewsInData: true,

        providers: [
            {
                name: 'youtube',
                url: [
                    /^(?:m\.)?youtube\.com\/watch\?v=([\w-]+)(?:&t=(\d+))?/,
                    /^(?:m\.)?youtube\.com\/v\/([\w-]+)(?:\?t=(\d+))?/,
                    /^youtube\.com\/embed\/([\w-]+)(?:\?start=(\d+))?/,
                    /^youtu\.be\/([\w-]+)(?:\?t=(\d+))?/
                ],
                html: match => {
                    const id = match[1];
                    
                    return (`<iframe
                              src="https://www.youtube-nocookie.com/embed/${id}"
                              frameborder="0"
                              allow="autoplay; encrypted-media" 
                              allowfullscreen />
                        `);
                }
            },
        ]
    }
}
```