### PR TITLE
fix image url with cloud providers

### DIFF
--- a/admin/src/components/Input/CKEditor/plugins/StrapiUploadAdapter.js
+++ b/admin/src/components/Input/CKEditor/plugins/StrapiUploadAdapter.js
@@ -140,12 +140,8 @@ class Adapter {
       }
 
       const { backendUrl, responsive } = this.options || {};
-      const { name, url, alternativeText, formats } = response[0];
-
-      // If using a cloud provider, url will be a full URL.
-      const defaultUrl = url.includes("https")
-        ? response[0].url
-        : backendUrl + response[0].url;
+      const { name, url, alternativeText, formats, provider } = response[0];
+      const defaultUrl = provider !== "local" ? url : backendUrl + url;
 
       if (formats && responsive) {
         let urls = { default: defaultUrl };

--- a/admin/src/components/Input/CKEditor/plugins/StrapiUploadAdapter.js
+++ b/admin/src/components/Input/CKEditor/plugins/StrapiUploadAdapter.js
@@ -24,7 +24,6 @@ export default class StrapiUploadAdapter extends Plugin {
    * @inheritDoc
    */
   init() {
-    
     // backendUrl
     // uploadUrl
     // headers
@@ -140,21 +139,27 @@ class Adapter {
         );
       }
 
-      
       const { backendUrl, responsive } = this.options || {};
-      
-      if (response[0].formats && responsive) {
-        const { name, url, alternativeText, formats } = response[0];
-        let urls = { default: backendUrl + url };
-        let keys = Object.keys(formats).sort((a, b) => formats[a].width - formats[b].width);
+      const { name, url, alternativeText, formats } = response[0];
+
+      // If using a cloud provider, url will be a full URL.
+      const defaultUrl = url.includes("https")
+        ? response[0].url
+        : backendUrl + response[0].url;
+
+      if (formats && responsive) {
+        let urls = { default: defaultUrl };
+        let keys = Object.keys(formats).sort(
+          (a, b) => formats[a].width - formats[b].width
+        );
         keys.map((k) => (urls[formats[k].width] = backendUrl + formats[k].url));
         resolve({ alt: alternativeText || name, urls: urls });
       } else {
         resolve(
-          response[0].url
+          url
             ? {
-                alt: response[0].alternativeText || response[0].name,
-                urls: { default: backendUrl + response[0].url },
+                alt: alternativeText || name,
+                urls: { default: defaultUrl },
               }
             : null
         );


### PR DESCRIPTION
### What does it do?
This PR updates the `StrapiUploadAdapter.js` plugin to check for a full image url before prefixing `backendUrl` to an uploaded image url.

### Why is it needed?
On Strapi instances with a cloud provider configured, images uploaded via the editor have a malformed URL. This breaks the editor preview as well.

The cause of the problem is that the StrapiUploadAdapter plugin automatically prepends every image upload url with the `backendUrl` variable resulting in image urls that look like this —

```
![alt](https://strapi-server-url.comhttps://path-to-image.png)
```

Strapi Cloud Upload provider plugins like [@strapi-community/strapi-provider-upload-google-cloud-storage](https://github.com/strapi-community/strapi-provider-upload-google-cloud-storage) and [@provider-upload-aws-s3](@strapi/provider-upload-aws-s3) return a fully formed url so there's no need to prepend the `backendUrl`.

### Related issue(s)/PR(s)
#72 
