### PR TITLE
Implement fullscreen toolbar toggle option

### DIFF
--- a/admin/src/components/Input/CKEditor/plugins/FullScreen.js
+++ b/admin/src/components/Input/CKEditor/plugins/FullScreen.js
@@ -1,0 +1,55 @@
+import "../../../../../../assets/fullscreen-plugin.css";
+
+const ImageFullBig = `<svg enable-background="new 0 0 32 32" height="32px" id="svg2" version="1.1" viewBox="0 0 32 32" width="32px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg"><g id="background"><rect fill="none" height="32" width="32"/></g><g id="fullscreen"><path d="M20,8l8,8V8H20z M4,24h8l-8-8V24z"/><path d="M32,28V4H0v24h14v2H8v2h16v-2h-6v-2H32z M2,26V6h28v20H2z"/></g></svg>`;
+const ImageFullCancel = `<svg enable-background="new 0 0 32 32" height="32px" id="svg2" version="1.1" viewBox="0 0 32 32" width="32px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg"><g id="background"><rect fill="none" height="32" width="32"/></g><g id="fullscreen_x5F_cancel"><path d="M4,16v8h8L4,16z M0,4v24h14v2H8v2h16v-0.06c2.702-0.299,5.042-1.791,6.481-3.94H32V4H0z M23,29.999   c-3.865-0.008-6.994-3.135-7-6.999c0.006-3.865,3.135-6.994,7-7c3.864,0.006,6.991,3.135,6.999,7   C29.991,26.864,26.864,29.991,23,29.999z M30,17.35c-0.57-0.707-1.244-1.326-2-1.832V8h-8l6.896,6.896   C25.717,14.328,24.398,14,23,14c-4.972,0-9,4.028-9,9c0,1.054,0.19,2.061,0.523,3H2V6h28V17.35z"/><polygon points="19,25 21,27 23,25 25,27 27,25 25,23 27,21 25,19 23,21 21,19 19,21 21,23  "/></g></svg>`;
+
+const Plugin = window.CKEditor5.core.Plugin;
+const ButtonView = window.CKEditor5.ui.ButtonView;
+
+export default class FullScreen extends Plugin {
+  static get pluginName() {
+    return "FullScreen";
+  }
+
+  init() {
+    const editor = this.editor;
+
+    editor.ui.componentFactory.add("fullScreen", () => {
+      const view = new ButtonView();
+      let etat = 0; //si 0 position normale
+      view.set({
+        label: "Full Screen",
+        icon: ImageFullBig,
+        tooltip: true,
+      });
+
+      // Callback executed once the image is clicked.
+      view.on("execute", () => {
+        if (etat == 1) {
+          editor.sourceElement.nextElementSibling.removeAttribute("id");
+          document.body.removeAttribute("id");
+          view.set({
+            label: "Full Screen",
+            icon: ImageFullBig,
+            tooltip: true,
+          });
+          etat = 0;
+        } else {
+          editor.sourceElement.nextElementSibling.setAttribute(
+            "id",
+            "fullscreeneditor"
+          );
+          document.body.setAttribute("id", "fullscreenoverlay");
+          view.set({
+            label: "Normal Mode",
+            icon: ImageFullCancel,
+            tooltip: true,
+          });
+          etat = 1;
+        }
+      });
+
+      return view;
+    });
+  }
+}

--- a/assets/fullscreen-plugin.css
+++ b/assets/fullscreen-plugin.css
@@ -1,0 +1,18 @@
+#fullscreenoverlay {
+	overflow: hidden;
+}
+
+#fullscreeneditor {
+  position: fixed !important;
+	top:0;
+	left: 0;
+	right:0;
+	bottom: 0;
+	z-index:1000;
+}
+
+#fullscreeneditor .ck-editor__editable.ck-rounded-corners.ck-editor__editable_inline, #fullscreeneditor .ck.ck-editor__main {
+    background-color: #fff;
+    height: 100%;
+    min-height: 100%;
+}


### PR DESCRIPTION
### What does it do?
This pull request adds a fullscreen toggle option to the editor plugin, allowing users to switch between a full screen mode and a regular mode.

### Why is it needed?
This feature is implemented to enhance the user experience by providing a distraction-free environment for editing.

The fullscreen toggle option can be accessed by clicking on the fullscreen icon located in the toolbar. When activated, the editor will enter full screen mode, hiding all other elements of the UI, and filling the entire screen.

In addition, this PR includes necessary modifications to the existing codebase to support the new feature. The implementation is based on this plugin by [leknoppix](https://github.com/leknoppix/ckeditor5-fullscreen)

Would appreciate people to test for as confidence as there are no tests implemented.

### Related issue(s)/PR(s)
#74
