### PR TITLE
Add information about custom field usage at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ or
 yarn build
 ```
 
+> 💡 **NOTE:** Since version 2 this plugin works through custom field API it doesn't change the default editor anymore instead it adds a new custom field https://youtu.be/hIKfvLzN6VI
+
 
 
 ## <a id="configuration"></a>⚙️ Configuration


### PR DESCRIPTION
### What does it do?

Documentation for v2 custom field usage.

### Why is it needed?

Some users feels that the plugin does not work because they are expecting the plugin to replace the default rich text editor.

### Related issue(s)/PR(s)

#66 and #62 
