### PR TITLE
Fix incorrect URL in srcset attribute for responsive images when using provider

### DIFF
--- a/admin/src/components/Input/CKEditor/plugins/StrapiUploadAdapter.js
+++ b/admin/src/components/Input/CKEditor/plugins/StrapiUploadAdapter.js
@@ -148,7 +148,7 @@ class Adapter {
         let keys = Object.keys(formats).sort(
           (a, b) => formats[a].width - formats[b].width
         );
-        keys.map((k) => (urls[formats[k].width] = provider !== 'local' ? url : backendUrl + formats[k].url));
+        keys.map((k) => (urls[formats[k].width] = provider !== 'local' ? formats[k].url : backendUrl + formats[k].url));
         resolve({ alt: alternativeText || name, urls: urls });
       } else {
         resolve(


### PR DESCRIPTION
## Description
This PR fixes an issue that occurs when using the provider in the editor. Previously, when pasting an image from the clipboard, the original image URL was incorrectly included in the srcset attribute of responsive images. This change ensures that `formats[k].url` is correctly included in the srcset of responsive images.

## Changes

- Updated the logic to include `formats[k].url` in the srcset of responsive images.

## How to Test

1. Open the editor and paste an image from the clipboard into the editor.
2. Verify that the image is uploaded successfully.
3. Check the source view to ensure that the srcset attribute of the pasted image correctly includes the URL.
