### PR TITLE
Update index.js

### DIFF
--- a/admin/src/components/Input/MediaLib/index.js
+++ b/admin/src/components/Input/MediaLib/index.js
@@ -23,10 +23,22 @@ const MediaLib = ({ isOpen, onChange, onToggle, editor, uploadConfig: { responsi
         newValue = `<a href="${prefixFileUrlWithBackendUrl(url)}" download="${name}">${name || "Download PDF"}</a>`;
       } else if (mime.includes("video")) {
         newValue = `
-            <video class="video" controls width="500px">
-                <source src="${prefixFileUrlWithBackendUrl(url)}" type="${mime}" />
-            <video/>`;
+        <video class="video" controls width="500px">
+            <source src="${prefixFileUrlWithBackendUrl(url)}" type="${mime}" />
+        </video>`;
+      } else {
+        newValue = `<a href="${prefixFileUrlWithBackendUrl(url)}" target="_blank" rel="noreferrer">${name || "Open Document"}</a>`;
       }
+      /** Adding support for Excel , msword, excel and other MS office extensions */
+      if (mime.includes("application/vnd.ms-powerpoint") ||
+      mime.includes("application/vnd.openxmlformats-officedocument.presentationml.presentation") ||
+      mime.includes("application/vnd.ms-excel") ||
+      mime.includes("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet") ||
+      mime.includes("application/msword") ||
+      mime.includes("application/vnd.openxmlformats-officedocument.wordprocessingml.document")) {
+      // Redirect to Microsoft Office Online Viewer;
+      newValue += `<a href=${prefixFileUrlWithBackendUrl(url)} target="_blank" rel="noreferrer">${name || "Open Document"}</a>`;
+}
     });
 
     const viewFragment = editor.data.processor.toView(newValue);

--- a/admin/src/components/Input/MediaLib/index.js
+++ b/admin/src/components/Input/MediaLib/index.js
@@ -26,19 +26,19 @@ const MediaLib = ({ isOpen, onChange, onToggle, editor, uploadConfig: { responsi
         <video class="video" controls width="500px">
             <source src="${prefixFileUrlWithBackendUrl(url)}" type="${mime}" />
         </video>`;
-      } else {
+       } /** Adding support for Excel , msword, excel and other MS office extensions */
+       else if (mime.includes("application/vnd.ms-powerpoint") ||
+       mime.includes("application/vnd.openxmlformats-officedocument.presentationml.presentation") ||
+       mime.includes("application/vnd.ms-excel") ||
+       mime.includes("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet") ||
+       mime.includes("application/msword") ||
+       mime.includes("application/vnd.openxmlformats-officedocument.wordprocessingml.document")) {
+       // Redirect to Microsoft Office Online Viewer;
+       newValue += `<a href=${prefixFileUrlWithBackendUrl(url)} target="_blank" rel="noreferrer">${name || "Open Document"}</a>`;
+ }
+      else {
         newValue = `<a href="${prefixFileUrlWithBackendUrl(url)}" target="_blank" rel="noreferrer">${name || "Open Document"}</a>`;
       }
-      /** Adding support for Excel , msword, excel and other MS office extensions */
-      if (mime.includes("application/vnd.ms-powerpoint") ||
-      mime.includes("application/vnd.openxmlformats-officedocument.presentationml.presentation") ||
-      mime.includes("application/vnd.ms-excel") ||
-      mime.includes("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet") ||
-      mime.includes("application/msword") ||
-      mime.includes("application/vnd.openxmlformats-officedocument.wordprocessingml.document")) {
-      // Redirect to Microsoft Office Online Viewer;
-      newValue += `<a href=${prefixFileUrlWithBackendUrl(url)} target="_blank" rel="noreferrer">${name || "Open Document"}</a>`;
-}
     });
 
     const viewFragment = editor.data.processor.toView(newValue);


### PR DESCRIPTION
Fix for https://github.com/nshenderov/strapi-plugin-ckeditor/issues/151

Adding support for Rich text editor to support MS office extensions.

### What does it do?

Added a condition  to support other MS office extensions in the Rich text editor.

### Why is it needed?

The Rich text editors (even the markdown editor default provided by strapi) gives the flexibility to the user for adding different file formats if need be i.e Excel , ppt , word doc etc. The current Ckeditor supports only image and PDF. 

### Related issue(s)/PR(s)

https://github.com/nshenderov/strapi-plugin-ckeditor/issues/151
