### PR TITLE
Export the admin utilities through the admin API

### DIFF
--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -1,11 +1,11 @@
 import * as yup from 'yup';
+import * as exports from './exports';
 
 import { PLUGIN_ID } from './utils';
 import { getPluginConfig, type Option } from './config';
 import { CKEditorIcon } from './components/CKEditorIcon';
 
 export * from './exports';
-import exports from './exports';
 
 const AVAILABLE_OPTIONS: Option[] = [];
 

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -5,6 +5,7 @@ import { getPluginConfig, type Option } from './config';
 import { CKEditorIcon } from './components/CKEditorIcon';
 
 export * from './exports';
+import exports from './exports';
 
 const AVAILABLE_OPTIONS: Option[] = [];
 
@@ -33,6 +34,13 @@ export default {
     fillAvailableOptions();
   },
   async register(app: any): Promise<void> {
+    app.registerPlugin({
+      id: PLUGIN_ID,
+      isReady: true,
+      name: 'CKEditor',
+      apis: exports,
+    });
+    
     app.customFields.register({
       name: 'CKEditor',
       type: 'richtext',


### PR DESCRIPTION
### What does it do?

This PR exposes the exports from `admin/src/exports.ts` to the plugins admin apis. Allowing users to import the utilities like so:

```
const { setPluginConfig, defaultHtmlPreset, defaultMarkdownPreset } = app.getPlugin('ckeditor5').apis;
```

### Why is it needed?

These utilities are rather useful in the scenario where a separate plugin wants to extend the Ckeditor config. However you currently need to import those utilities in to such a plugin, making `@_sh/strapi-plugin-ckeditor` a dependency. That isn't correct, and can cause `ckeditor-duplicated-modules ` errors when the Ckeditor plugin get's updated, but the dependency in the plugin does not.

In theory you could define the Ckeditor plugin as peer dependency of such a plugin, however that still doesn't fully solve the problem. In short:

1. Even if the Ckeditor plugin is installed in Strapi, the extension plugin will throw an error like this `[vite] Internal Server Error
Failed to resolve import "@_sh/strapi-plugin-ckeditor" from "...". Does the file exist?` if it doesn't have the Ckeditor plugin as a dependency.
2. In my case the Ckeditor extension is an optional feature of my plugin. So defining a peer dependency wouldn't make sense because you're not required to have it installed. Which will again cause problem nr 1.

The solution is to just expose the required utilities through the plugin apis. We can now just use them when they're there, and skip the implementation when they're not. No conflicting versions, just one Ckeditor plugin version.

### Related issue(s)/PR(s)

None
